### PR TITLE
Change ProxyConfig.VerboseLevel to ProxyConfig.LogLevel

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,6 +2,8 @@ package mongonet
 
 import "fmt"
 
+import "github.com/mongodb/slogger/v2/slogger"
+
 type SSLPair struct {
 	CertFile string
 	KeyFile  string
@@ -18,7 +20,7 @@ type ProxyConfig struct {
 	UseSSL  bool
 	SSLKeys []SSLPair
 
-	VerboseLevel int
+	LogLevel slogger.Level
 
 	InterceptorFactory ProxyInterceptorFactory
 

--- a/proxy.go
+++ b/proxy.go
@@ -297,15 +297,7 @@ func NewProxy(pc ProxyConfig) Proxy {
 }
 
 func (p *Proxy) NewLogger(prefix string) *slogger.Logger {
-
-	level := slogger.INFO
-	if p.config.VerboseLevel == 1 {
-		level = slogger.DEBUG
-	} else if p.config.VerboseLevel == 2 {
-		level = slogger.OFF
-	}
-
-	filters := []slogger.TurboFilter{slogger.TurboLevelFilter(level)}
+	filters := []slogger.TurboFilter{slogger.TurboLevelFilter(p.config.LogLevel)}
 
 	return &slogger.Logger{prefix, []slogger.Appender{slogger.StdOutAppender()}, 0, filters}
 }


### PR DESCRIPTION
This allows for the full range of slogger log levels.  Incidentally removes the idiosyncrasy that the highest verbose level was OFF.