### PR TITLE
Add ProxyConfig.Appenders

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,7 +20,8 @@ type ProxyConfig struct {
 	UseSSL  bool
 	SSLKeys []SSLPair
 
-	LogLevel slogger.Level
+	LogLevel  slogger.Level
+	Appenders []slogger.Appender
 
 	InterceptorFactory ProxyInterceptorFactory
 
@@ -36,9 +37,10 @@ func NewProxyConfig(bindHost string, bindPort int, mongoHost string, mongoPort i
 		false, // MongoSSL
 		false, // UseSSL
 		nil,
-		0,   // VerboseLevel
-		nil, // InterceptorFactory
-		nil, // ConnectionPoolHook
+		slogger.OFF, // LogLevel
+		nil,         // Appenders
+		nil,         // InterceptorFactory
+		nil,         // ConnectionPoolHook
 	}
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -299,7 +299,12 @@ func NewProxy(pc ProxyConfig) Proxy {
 func (p *Proxy) NewLogger(prefix string) *slogger.Logger {
 	filters := []slogger.TurboFilter{slogger.TurboLevelFilter(p.config.LogLevel)}
 
-	return &slogger.Logger{prefix, []slogger.Appender{slogger.StdOutAppender()}, 0, filters}
+	appenders := p.config.Appenders
+	if appenders == nil {
+		appenders = []slogger.Appender{slogger.StdOutAppender()}
+	}
+
+	return &slogger.Logger{prefix, appenders, 0, filters}
 }
 
 func (p *Proxy) Run() error {


### PR DESCRIPTION
This allows us to customize the slogger appenders that Proxy uses.  For example, we can redirect logging to a file.  