### PR TITLE
Do not set QueryFailure bit for failing OP_QUERY and OP_GET_MORE requests

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -161,7 +161,11 @@ func (ps *ProxySession) respondWithError(clientMessage Message, err error) error
 				17, // TODO
 				clientMessage.Header().RequestID,
 				OP_REPLY},
-			2, // flags - error bit
+
+			// We should not set the error bit because we are
+			// responding with errmsg instead of $err
+			0, // flags - error bit
+
 			0, // cursor id
 			0, // StartingFrom
 			1, // NumberReturned


### PR DESCRIPTION
Some clients expect that if the QueryFailure bit is set then $err must be sent.  But since we always send errmsg instead of $err for OP_QUERY and OP_GET_MORE then we should also not set the QueryFailure bit.